### PR TITLE
Fix bug that triggers if farming isn't present.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -381,7 +381,7 @@ instant_ores.register_toolset = function(mod, name, desc, color, level, ingredie
 		}	
 	})
 
-	if farming then
+	if minetest.get_modpath("farming") then
 		farming.register_hoe(mod..":hoe_"..name, {
 			description = desc.." Hoe",
 			inventory_image = "tool_base.png^tool_hoe_base.png^(tool_hoe.png^[colorize:"..color..")",


### PR DESCRIPTION
If you load a world that does not have farming (ex by removing it from MT-game) then it would have raised an error and crashed the server due to an undefined global variable, `farming`.

This is a competitor to https://notabug.org/Piezo_/instant_ores/pulls/2

## The Fix

use getmodpath to get if the mod is present or not.