### PR TITLE
Add support for pickaxe tweaks integration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -305,6 +305,10 @@ instant_ores.register_toolset = function(mod, name, desc, color, level, ingredie
 		}	
 	})
 
+	if minetest.get_modpath("pick_axe_tweaks") then
+		pick_axe_tweaks.register_pick_axes({mod..":pick_"..name})
+	end
+
 	maketool(":"..mod..":shovel_"..name, {
 		description = desc.." Shovel",
 		inventory_image = "tool_base.png^tool_shovel_base.png^(tool_shovel.png^[colorize:"..color..")",

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = instant_ores
 description = A minetest mod that gives developers a stupidly simple system to add new ores with basically no effort.
 depends = default
-optional_depends = farming, 3d_armor
+optional_depends = farming, 3d_armor, pick_axe_tweaks


### PR DESCRIPTION
if present will register the pickaxe under this mod.

https://content.minetest.net/packages/wsor4035/pick_axe_tweaks/

It's possible that this might conflict with #1 because of the changes to mod.conf but it's a very easy to fix conflict.

Competitor with https://notabug.org/Piezo_/instant_ores/pulls/3