### PR TITLE
Add handholds_redo support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -305,6 +305,10 @@ instant_ores.register_toolset = function(mod, name, desc, color, level, ingredie
 		}	
 	})
 
+	if minetest.get_modpath("handholds_redo") then
+		handholds.register_pick(mod..":pick_"..name,level)
+	end
+
 	maketool(":"..mod..":shovel_"..name, {
 		description = desc.." Shovel",
 		inventory_image = "tool_base.png^tool_shovel_base.png^(tool_shovel.png^[colorize:"..color..")",

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = instant_ores
 description = A minetest mod that gives developers a stupidly simple system to add new ores with basically no effort.
 depends = default
-optional_depends = farming, 3d_armor
+optional_depends = farming, 3d_armor, handholds_redo


### PR DESCRIPTION
https://content.minetest.net/packages/TestificateMods/handholds_redo/

Much like #3 adds support for this mod if it exsists.

One note though: this PR might conflict with #3. If it does, be sure to register this one after pickaxe tweaks (this conclusion is the result of my testing). I'll be keeping an eye out to make sure that when you do merge a PR I might be able to make these minor conflicts even easier to deal with.

Here's what that would look like:

```lua
    -- ...
    if minetest.get_modpath("pick_axe_tweaks") then
        pick_axe_tweaks.register_pick_axes({mod..":pick_"..name})
    end
    if minetest.get_modpath("handholds_redo") then
        handholds.register_pick(mod..":pick_"..name,level)
    end
    -- ...
```

Competitor with https://notabug.org/Piezo_/instant_ores/pulls/4